### PR TITLE
Add API Endpoint Test Cases and Mock Service Implementation

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.13.1"
+version = "2.13.2"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -107,6 +107,9 @@ version = "1.7.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
+]
+modules = [
+	{org = "ballerina", packageName = "io", moduleName = "io"}
 ]
 
 [[package]]
@@ -151,6 +154,15 @@ dependencies = [
 org = "ballerina"
 name = "lang.decimal"
 version = "0.0.0"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.error"
+version = "0.0.0"
+scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -237,6 +249,9 @@ dependencies = [
 	{org = "ballerina", name = "time"},
 	{org = "ballerina", name = "url"}
 ]
+modules = [
+	{org = "ballerina", packageName = "oauth2", moduleName = "oauth2"}
+]
 
 [[package]]
 org = "ballerina"
@@ -254,6 +269,9 @@ dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"}
 ]
+modules = [
+	{org = "ballerina", packageName = "os", moduleName = "os"}
+]
 
 [[package]]
 org = "ballerina"
@@ -262,6 +280,20 @@ version = "2.6.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
+]
+
+[[package]]
+org = "ballerina"
+name = "test"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.array"},
+	{org = "ballerina", name = "lang.error"}
+]
+modules = [
+	{org = "ballerina", packageName = "test", moduleName = "test"}
 ]
 
 [[package]]
@@ -301,6 +333,10 @@ name = "hubspot.crm.associations.schema"
 version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "oauth2"},
+	{org = "ballerina", name = "os"},
+	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "url"},
 	{org = "ballerinai", name = "observe"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -108,9 +108,6 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
 ]
-modules = [
-	{org = "ballerina", packageName = "io", moduleName = "io"}
-]
 
 [[package]]
 org = "ballerina"
@@ -333,7 +330,6 @@ name = "hubspot.crm.associations.schema"
 version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
-	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "oauth2"},
 	{org = "ballerina", name = "os"},
 	{org = "ballerina", name = "test"},

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -22,13 +22,24 @@ import ballerina/http;
 public isolated client class Client {
     final http:Client clientEp;
     final readonly & ApiKeysConfig? apiKeyConfig;
+
     # Gets invoked to initialize the `connector`.
     #
     # + config - The configurations to be used when initializing the `connector` 
     # + serviceUrl - URL of the target service 
     # + return - An error if connector initialization failed 
-    public isolated function init(ConnectionConfig config, string serviceUrl = "https://api.hubapi.com/crm/v4/associations") returns error? {
-        http:ClientConfiguration httpClientConfig = {httpVersion: config.httpVersion, timeout: config.timeout, forwarded: config.forwarded, poolConfig: config.poolConfig, compression: config.compression, circuitBreaker: config.circuitBreaker, retryConfig: config.retryConfig, validation: config.validation};
+    public isolated function init(ConnectionConfig config,
+            string serviceUrl = "https://api.hubapi.com/crm/v4/associations") returns error? {
+        http:ClientConfiguration httpClientConfig = {
+            httpVersion: config.httpVersion,
+            timeout: config.timeout,
+            forwarded: config.forwarded,
+            poolConfig: config.poolConfig,
+            compression: config.compression,
+            circuitBreaker: config.circuitBreaker,
+            retryConfig: config.retryConfig,
+            validation: config.validation
+        };
         do {
             if config.http1Settings is ClientHttp1Settings {
                 ClientHttp1Settings settings = check config.http1Settings.ensureType(ClientHttp1Settings);
@@ -65,8 +76,12 @@ public isolated client class Client {
     #
     # + headers - Headers to be sent with the request 
     # + return - No content 
-    resource isolated function delete [string fromObjectType]/[string toObjectType]/labels/[int:Signed32 associationTypeId](map<string|string[]> headers = {}) returns http:Response|error {
-        string resourcePath = string `/${getEncodedUri(fromObjectType)}/${getEncodedUri(toObjectType)}/labels/${getEncodedUri(associationTypeId)}`;
+    resource isolated function delete
+    [string fromObjectType]/[string toObjectType]/labels/[int:Signed32 associationTypeId]
+            (map<string|string[]> headers = {})
+    returns http:Response|error {
+        string resourcePath = string
+        `/${getEncodedUri(fromObjectType)}/${getEncodedUri(toObjectType)}/labels/${getEncodedUri(associationTypeId)}`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["private-app"] = self.apiKeyConfig?.private\-app;
@@ -80,7 +95,10 @@ public isolated client class Client {
     #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
-    resource isolated function get [string fromObjectType]/[string toObjectType]/labels(map<string|string[]> headers = {}) returns CollectionResponseAssociationSpecWithLabelNoPaging|error {
+    resource isolated function get
+    [string fromObjectType]/[string toObjectType]/labels
+            (map<string|string[]> headers = {})
+    returns CollectionResponseAssociationSpecWithLabelNoPaging|error {
         string resourcePath = string `/${getEncodedUri(fromObjectType)}/${getEncodedUri(toObjectType)}/labels`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
@@ -95,8 +113,12 @@ public isolated client class Client {
     #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
-    resource isolated function get definitions/configurations/[string fromObjectType]/[string toObjectType](map<string|string[]> headers = {}) returns CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging|error {
-        string resourcePath = string `/definitions/configurations/${getEncodedUri(fromObjectType)}/${getEncodedUri(toObjectType)}`;
+    resource isolated function get
+    definitions/configurations/[string fromObjectType]/[string toObjectType]
+            (map<string|string[]> headers = {})
+    returns CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging|error {
+        string resourcePath = string
+        `/definitions/configurations/${getEncodedUri(fromObjectType)}/${getEncodedUri(toObjectType)}`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["private-app"] = self.apiKeyConfig?.private\-app;
@@ -110,7 +132,10 @@ public isolated client class Client {
     #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
-    resource isolated function get definitions/configurations/all(map<string|string[]> headers = {}) returns CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging|error {
+    resource isolated function get
+    definitions/configurations/all
+            (map<string|string[]> headers = {})
+    returns CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging|error {
         string resourcePath = string `/definitions/configurations/all`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
@@ -125,7 +150,10 @@ public isolated client class Client {
     #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
-    resource isolated function post [string fromObjectType]/[string toObjectType]/labels(PublicAssociationDefinitionCreateRequest payload, map<string|string[]> headers = {}) returns CollectionResponseAssociationSpecWithLabelNoPaging|error {
+    resource isolated function post
+    [string fromObjectType]/[string toObjectType]/labels
+            (PublicAssociationDefinitionCreateRequest payload, map<string|string[]> headers = {})
+    returns CollectionResponseAssociationSpecWithLabelNoPaging|error {
         string resourcePath = string `/${getEncodedUri(fromObjectType)}/${getEncodedUri(toObjectType)}/labels`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
@@ -143,8 +171,13 @@ public isolated client class Client {
     #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
-    resource isolated function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/create(BatchInputPublicAssociationDefinitionConfigurationCreateRequest payload, map<string|string[]> headers = {}) returns BatchResponsePublicAssociationDefinitionUserConfiguration|BatchResponsePublicAssociationDefinitionUserConfigurationWithErrors|error {
-        string resourcePath = string `/definitions/configurations/${getEncodedUri(fromObjectType)}/${getEncodedUri(toObjectType)}/batch/create`;
+    resource isolated function post
+    definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/create
+            (BatchInputPublicAssociationDefinitionConfigurationCreateRequest payload, map<string|string[]> headers = {})
+    returns BatchResponsePublicAssociationDefinitionUserConfiguration|
+    BatchResponsePublicAssociationDefinitionUserConfigurationWithErrors|error {
+        string resourcePath = string
+        `/definitions/configurations/${getEncodedUri(fromObjectType)}/${getEncodedUri(toObjectType)}/batch/create`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["private-app"] = self.apiKeyConfig?.private\-app;
@@ -161,8 +194,12 @@ public isolated client class Client {
     #
     # + headers - Headers to be sent with the request 
     # + return - No content 
-    resource isolated function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/purge(BatchInputPublicAssociationSpec payload, map<string|string[]> headers = {}) returns http:Response|error {
-        string resourcePath = string `/definitions/configurations/${getEncodedUri(fromObjectType)}/${getEncodedUri(toObjectType)}/batch/purge`;
+    resource isolated function post
+    definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/purge
+            (BatchInputPublicAssociationSpec payload, map<string|string[]> headers = {})
+    returns http:Response|error {
+        string resourcePath = string
+        `/definitions/configurations/${getEncodedUri(fromObjectType)}/${getEncodedUri(toObjectType)}/batch/purge`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["private-app"] = self.apiKeyConfig?.private\-app;
@@ -179,8 +216,13 @@ public isolated client class Client {
     #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
-    resource isolated function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/update(BatchInputPublicAssociationDefinitionConfigurationUpdateRequest payload, map<string|string[]> headers = {}) returns BatchResponsePublicAssociationDefinitionConfigurationUpdateResult|BatchResponsePublicAssociationDefinitionConfigurationUpdateResultWithErrors|error {
-        string resourcePath = string `/definitions/configurations/${getEncodedUri(fromObjectType)}/${getEncodedUri(toObjectType)}/batch/update`;
+    resource isolated function post
+    definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/update
+            (BatchInputPublicAssociationDefinitionConfigurationUpdateRequest payload, map<string|string[]> headers = {})
+    returns BatchResponsePublicAssociationDefinitionConfigurationUpdateResult|
+    BatchResponsePublicAssociationDefinitionConfigurationUpdateResultWithErrors|error {
+        string resourcePath = string
+        `/definitions/configurations/${getEncodedUri(fromObjectType)}/${getEncodedUri(toObjectType)}/batch/update`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["private-app"] = self.apiKeyConfig?.private\-app;
@@ -197,7 +239,10 @@ public isolated client class Client {
     #
     # + headers - Headers to be sent with the request 
     # + return - No content 
-    resource isolated function put [string fromObjectType]/[string toObjectType]/labels(PublicAssociationDefinitionUpdateRequest payload, map<string|string[]> headers = {}) returns http:Response|error {
+    resource isolated function put
+    [string fromObjectType]/[string toObjectType]/labels(PublicAssociationDefinitionUpdateRequest payload,
+            map<string|string[]> headers = {})
+    returns http:Response|error {
         string resourcePath = string `/${getEncodedUri(fromObjectType)}/${getEncodedUri(toObjectType)}/labels`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {

--- a/ballerina/tests/mock_service.bal
+++ b/ballerina/tests/mock_service.bal
@@ -1,0 +1,185 @@
+// Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+
+service on new http:Listener(9090) {
+    resource function delete [string fromObjectType]/[string toObjectType]/labels/[int:Signed32 associationTypeId]() returns http:NoContent|error {
+        return http:NO_CONTENT;
+    }
+    resource function get [string fromObjectType]/[string toObjectType]/labels() returns CollectionResponseAssociationSpecWithLabelNoPaging|error {
+        return {
+            "results": [
+                {
+                    "category": "HUBSPOT_DEFINED",
+                    "typeId": 4,
+                    "label": null
+                },
+                {
+                    "category": "USER_DEFINED",
+                    "typeId": 543,
+                    "label": "label"
+                }
+            ]
+        };
+    }
+    resource function get definitions/configurations/[string fromObjectType]/[string toObjectType]() returns CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging|error {
+        return {
+            "results": [
+                {
+                    "category": "HUBSPOT_DEFINED",
+                    "typeId": 4,
+                    "userEnforcedMaxToObjectIds": 2,
+                    "label": null
+                }
+            ]
+        };
+    }
+    resource function get definitions/configurations/all() returns CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging|error {
+        return {
+            "results": [
+                {
+                    "category": "HUBSPOT_DEFINED",
+                    "typeId": 4,
+                    "userEnforcedMaxToObjectIds": 2,
+                    "label": null
+                },
+                {
+                    "category": "HUBSPOT_DEFINED",
+                    "typeId": 3,
+                    "userEnforcedMaxToObjectIds": null,
+                    "label": null
+                }
+            ]
+        };
+    }
+    resource function post [string fromObjectType]/[string toObjectType]/labels(@http:Payload PublicAssociationDefinitionCreateRequest payload) returns CollectionResponseAssociationSpecWithLabelNoPaging|http:BadRequest {
+        if (payload.label == null) {
+            return http:BAD_REQUEST;
+        }
+        return {
+            "results": [
+                {
+                    "category": "USER_DEFINED",
+                    "typeId": 546,
+                    "label": "label"
+                },
+                {
+                    "category": "USER_DEFINED",
+                    "typeId": 545,
+                    "label": "inverseLabel"
+                }
+            ]
+        };
+    }
+    resource function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/create(@http:Payload BatchInputPublicAssociationDefinitionConfigurationCreateRequest payload) returns BatchResponsePublicAssociationDefinitionUserConfiguration|error {
+        if (payload.inputs[0].typeId == -1) {
+            return {
+                "status": "CANCELED",
+                "results": [],
+                "numErrors": 1,
+                "errors": [
+                    {
+                        "status": "error",
+                        "category": "VALIDATION_ERROR",
+                        "subCategory": "crm.associations.INVALID_ASSOCIATION_TYPE",
+                        "message": "0--1 is not a valid association type between CONTACT and DEAL",
+                        "context": {
+                            "type": [
+                                "0-5"
+                            ],
+                            "fromObjectType": [
+                                "CONTACT"
+                            ],
+                            "toObjectType": [
+                                "DEAL"
+                            ]
+                        }
+                    }
+                ],
+                "startedAt": "2025-02-19T07:03:44.442Z",
+                "completedAt": "2025-02-19T07:03:44.475Z"
+            };
+        }
+        return {
+            "status": "COMPLETE",
+            "results": [
+                {
+                    "category": "HUBSPOT_DEFINED",
+                    "typeId": 4,
+                    "userEnforcedMaxToObjectIds": 2,
+                    "label": null
+                }
+            ],
+            "startedAt": "2025-02-19T05:28:18.851Z",
+            "completedAt": "2025-02-19T05:28:18.911Z"
+        };
+    }
+    resource function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/purge(@http:Payload BatchInputPublicAssociationSpec payload) returns http:NoContent|http:BadRequest|http:MultiStatus {
+        if (payload.inputs[0].typeId == 5) {
+            return http:BAD_REQUEST;
+        }
+        return http:NO_CONTENT;
+    }
+    resource function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/update(@http:Payload BatchInputPublicAssociationDefinitionConfigurationUpdateRequest payload) returns BatchResponsePublicAssociationDefinitionConfigurationUpdateResult|error {
+        if (payload.inputs[0].typeId == 5) {
+            return {
+                "status": "CANCELED",
+                "results": [],
+                "numErrors": 1,
+                "errors": [
+                    {
+                        "status": "error",
+                        "category": "VALIDATION_ERROR",
+                        "subCategory": "crm.associations.INVALID_ASSOCIATION_TYPE",
+                        "message": "0-5 is not a valid association type between CONTACT and DEAL",
+                        "context": {
+                            "type": [
+                                "0-5"
+                            ],
+                            "fromObjectType": [
+                                "CONTACT"
+                            ],
+                            "toObjectType": [
+                                "DEAL"
+                            ]
+                        }
+                    }
+                ],
+                "startedAt": "2025-02-19T07:03:44.442Z",
+                "completedAt": "2025-02-19T07:03:44.475Z"
+            };
+        }
+        return {
+            "status": "COMPLETE",
+            "results": [
+                {
+                    "category": "HUBSPOT_DEFINED",
+                    "typeId": 4,
+                    "userEnforcedMaxToObjectIds": 11
+                }
+            ],
+            "startedAt": "2025-02-19T05:45:32.920Z",
+            "completedAt": "2025-02-19T05:45:32.957Z"
+        };
+    }
+    resource function put [string fromObjectType]/[string toObjectType]/labels(@http:Payload PublicAssociationDefinitionUpdateRequest payload) returns http:NoContent|http:BadRequest {
+        if (payload.label == null || payload.associationTypeId == -1) {
+            return http:BAD_REQUEST;
+        }
+        return http:NO_CONTENT;
+    }
+}

--- a/ballerina/tests/mock_service.bal
+++ b/ballerina/tests/mock_service.bal
@@ -67,7 +67,7 @@ service on new http:Listener(9090) {
         };
     }
     resource function post [string fromObjectType]/[string toObjectType]/labels(@http:Payload PublicAssociationDefinitionCreateRequest payload) returns CollectionResponseAssociationSpecWithLabelNoPaging|http:BadRequest {
-        if (payload.label == null) {
+        if payload.label == null {
             return http:BAD_REQUEST;
         }
         return {
@@ -86,7 +86,7 @@ service on new http:Listener(9090) {
         };
     }
     resource function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/create(@http:Payload BatchInputPublicAssociationDefinitionConfigurationCreateRequest payload) returns BatchResponsePublicAssociationDefinitionUserConfiguration|error {
-        if (payload.inputs[0].typeId == -1) {
+        if payload.inputs[0].typeId == -1 {
             return {
                 "status": "CANCELED",
                 "results": [],
@@ -129,13 +129,13 @@ service on new http:Listener(9090) {
         };
     }
     resource function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/purge(@http:Payload BatchInputPublicAssociationSpec payload) returns http:NoContent|http:BadRequest|http:MultiStatus {
-        if (payload.inputs[0].typeId == 5) {
+        if payload.inputs[0].typeId == 5 {
             return http:BAD_REQUEST;
         }
         return http:NO_CONTENT;
     }
     resource function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/update(@http:Payload BatchInputPublicAssociationDefinitionConfigurationUpdateRequest payload) returns BatchResponsePublicAssociationDefinitionConfigurationUpdateResult|error {
-        if (payload.inputs[0].typeId == 5) {
+        if payload.inputs[0].typeId == 5 {
             return {
                 "status": "CANCELED",
                 "results": [],
@@ -177,7 +177,7 @@ service on new http:Listener(9090) {
         };
     }
     resource function put [string fromObjectType]/[string toObjectType]/labels(@http:Payload PublicAssociationDefinitionUpdateRequest payload) returns http:NoContent|http:BadRequest {
-        if (payload.label == null || payload.associationTypeId == -1) {
+        if payload.label == null || payload.associationTypeId == -1 {
             return http:BAD_REQUEST;
         }
         return http:NO_CONTENT;

--- a/ballerina/tests/mock_service.bal
+++ b/ballerina/tests/mock_service.bal
@@ -23,16 +23,16 @@ service on new http:Listener(9090) {
 
     resource function get [string fromObjectType]/[string toObjectType]/labels() returns CollectionResponseAssociationSpecWithLabelNoPaging|error {
         return {
-            "results": [
+            results: [
                 {
-                    "category": "HUBSPOT_DEFINED",
-                    "typeId": 4,
-                    "label": null
+                    category: "HUBSPOT_DEFINED",
+                    typeId: 4,
+                    label: null
                 },
                 {
-                    "category": "USER_DEFINED",
-                    "typeId": 543,
-                    "label": "label"
+                    category: "USER_DEFINED",
+                    typeId: 543,
+                    label: "label"
                 }
             ]
         };
@@ -40,12 +40,12 @@ service on new http:Listener(9090) {
 
     resource function get definitions/configurations/[string fromObjectType]/[string toObjectType]() returns CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging|error {
         return {
-            "results": [
+            results: [
                 {
-                    "category": "HUBSPOT_DEFINED",
-                    "typeId": 4,
-                    "userEnforcedMaxToObjectIds": 2,
-                    "label": null
+                    category: "HUBSPOT_DEFINED",
+                    typeId: 4,
+                    userEnforcedMaxToObjectIds: 2,
+                    label: null
                 }
             ]
         };
@@ -53,18 +53,18 @@ service on new http:Listener(9090) {
 
     resource function get definitions/configurations/all() returns CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging|error {
         return {
-            "results": [
+            results: [
                 {
-                    "category": "HUBSPOT_DEFINED",
-                    "typeId": 4,
-                    "userEnforcedMaxToObjectIds": 2,
-                    "label": null
+                    category: "HUBSPOT_DEFINED",
+                    typeId: 4,
+                    userEnforcedMaxToObjectIds: 2,
+                    label: null
                 },
                 {
-                    "category": "HUBSPOT_DEFINED",
-                    "typeId": 3,
-                    "userEnforcedMaxToObjectIds": null,
-                    "label": null
+                    category: "HUBSPOT_DEFINED",
+                    typeId: 3,
+                    userEnforcedMaxToObjectIds: null,
+                    label: null
                 }
             ]
         };
@@ -75,16 +75,16 @@ service on new http:Listener(9090) {
             return http:BAD_REQUEST;
         }
         return {
-            "results": [
+            results: [
                 {
-                    "category": "USER_DEFINED",
-                    "typeId": 546,
-                    "label": "label"
+                    category: "USER_DEFINED",
+                    typeId: 546,
+                    label: "label"
                 },
                 {
-                    "category": "USER_DEFINED",
-                    "typeId": 545,
-                    "label": "inverseLabel"
+                    category: "USER_DEFINED",
+                    typeId: 545,
+                    label: "inverseLabel"
                 }
             ]
         };
@@ -93,44 +93,24 @@ service on new http:Listener(9090) {
     resource function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/create(@http:Payload BatchInputPublicAssociationDefinitionConfigurationCreateRequest payload) returns BatchResponsePublicAssociationDefinitionUserConfiguration|error {
         if payload.inputs[0].typeId == -1 {
             return {
-                "status": "CANCELED",
-                "results": [],
-                "numErrors": 1,
-                "errors": [
-                    {
-                        "status": "error",
-                        "category": "VALIDATION_ERROR",
-                        "subCategory": "crm.associations.INVALID_ASSOCIATION_TYPE",
-                        "message": "0--1 is not a valid association type between CONTACT and DEAL",
-                        "context": {
-                            "type": [
-                                "0-5"
-                            ],
-                            "fromObjectType": [
-                                "CONTACT"
-                            ],
-                            "toObjectType": [
-                                "DEAL"
-                            ]
-                        }
-                    }
-                ],
-                "startedAt": "2025-02-19T07:03:44.442Z",
-                "completedAt": "2025-02-19T07:03:44.475Z"
+                status: "CANCELED",
+                results: [],
+                startedAt: "2025-02-19T07:03:44.442Z",
+                completedAt: "2025-02-19T07:03:44.475Z"
             };
         }
         return {
-            "status": "COMPLETE",
-            "results": [
+            status: "COMPLETE",
+            results: [
                 {
-                    "category": "HUBSPOT_DEFINED",
-                    "typeId": 4,
-                    "userEnforcedMaxToObjectIds": 2,
-                    "label": null
+                    category: "HUBSPOT_DEFINED",
+                    typeId: 4,
+                    userEnforcedMaxToObjectIds: 2,
+                    label: null
                 }
             ],
-            "startedAt": "2025-02-19T05:28:18.851Z",
-            "completedAt": "2025-02-19T05:28:18.911Z"
+            startedAt: "2025-02-19T05:28:18.851Z",
+            completedAt: "2025-02-19T05:28:18.911Z"
         };
     }
 
@@ -144,43 +124,23 @@ service on new http:Listener(9090) {
     resource function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/update(@http:Payload BatchInputPublicAssociationDefinitionConfigurationUpdateRequest payload) returns BatchResponsePublicAssociationDefinitionConfigurationUpdateResult|error {
         if payload.inputs[0].typeId == 5 {
             return {
-                "status": "CANCELED",
-                "results": [],
-                "numErrors": 1,
-                "errors": [
-                    {
-                        "status": "error",
-                        "category": "VALIDATION_ERROR",
-                        "subCategory": "crm.associations.INVALID_ASSOCIATION_TYPE",
-                        "message": "0-5 is not a valid association type between CONTACT and DEAL",
-                        "context": {
-                            "type": [
-                                "0-5"
-                            ],
-                            "fromObjectType": [
-                                "CONTACT"
-                            ],
-                            "toObjectType": [
-                                "DEAL"
-                            ]
-                        }
-                    }
-                ],
-                "startedAt": "2025-02-19T07:03:44.442Z",
-                "completedAt": "2025-02-19T07:03:44.475Z"
+                status: "CANCELED",
+                results: [],
+                startedAt: "2025-02-19T07:03:44.442Z",
+                completedAt: "2025-02-19T07:03:44.475Z"
             };
         }
         return {
-            "status": "COMPLETE",
-            "results": [
+            status: "COMPLETE",
+            results: [
                 {
-                    "category": "HUBSPOT_DEFINED",
-                    "typeId": 4,
-                    "userEnforcedMaxToObjectIds": 11
+                    category: "HUBSPOT_DEFINED",
+                    typeId: 4,
+                    userEnforcedMaxToObjectIds: 11
                 }
             ],
-            "startedAt": "2025-02-19T05:45:32.920Z",
-            "completedAt": "2025-02-19T05:45:32.957Z"
+            startedAt: "2025-02-19T05:45:32.920Z",
+            completedAt: "2025-02-19T05:45:32.957Z"
         };
     }
 

--- a/ballerina/tests/mock_service.bal
+++ b/ballerina/tests/mock_service.bal
@@ -17,11 +17,13 @@
 import ballerina/http;
 
 service on new http:Listener(9090) {
-    resource function delete [string fromObjectType]/[string toObjectType]/labels/[int:Signed32 associationTypeId]() returns http:NoContent|error {
+    resource function delete [string fromObjectType]/[string toObjectType]/labels/[int:Signed32 associationTypeId]()
+    returns http:NoContent|error {
         return http:NO_CONTENT;
     }
 
-    resource function get [string fromObjectType]/[string toObjectType]/labels() returns CollectionResponseAssociationSpecWithLabelNoPaging|error {
+    resource function get [string fromObjectType]/[string toObjectType]/labels()
+    returns CollectionResponseAssociationSpecWithLabelNoPaging|error {
         return {
             results: [
                 {
@@ -38,7 +40,8 @@ service on new http:Listener(9090) {
         };
     }
 
-    resource function get definitions/configurations/[string fromObjectType]/[string toObjectType]() returns CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging|error {
+    resource function get definitions/configurations/[string fromObjectType]/[string toObjectType]()
+    returns CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging|error {
         return {
             results: [
                 {
@@ -51,7 +54,8 @@ service on new http:Listener(9090) {
         };
     }
 
-    resource function get definitions/configurations/all() returns CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging|error {
+    resource function get definitions/configurations/all()
+    returns CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging|error {
         return {
             results: [
                 {
@@ -70,7 +74,9 @@ service on new http:Listener(9090) {
         };
     }
 
-    resource function post [string fromObjectType]/[string toObjectType]/labels(@http:Payload PublicAssociationDefinitionCreateRequest payload) returns CollectionResponseAssociationSpecWithLabelNoPaging|http:BadRequest {
+    resource function post [string fromObjectType]/[string toObjectType]/labels
+            (@http:Payload PublicAssociationDefinitionCreateRequest payload)
+    returns CollectionResponseAssociationSpecWithLabelNoPaging|http:BadRequest {
         if payload.label == null {
             return http:BAD_REQUEST;
         }
@@ -90,7 +96,9 @@ service on new http:Listener(9090) {
         };
     }
 
-    resource function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/create(@http:Payload BatchInputPublicAssociationDefinitionConfigurationCreateRequest payload) returns BatchResponsePublicAssociationDefinitionUserConfiguration|error {
+    resource function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/create
+            (@http:Payload BatchInputPublicAssociationDefinitionConfigurationCreateRequest payload)
+    returns BatchResponsePublicAssociationDefinitionUserConfiguration|error {
         if payload.inputs[0].typeId == -1 {
             return {
                 status: "CANCELED",
@@ -114,14 +122,18 @@ service on new http:Listener(9090) {
         };
     }
 
-    resource function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/purge(@http:Payload BatchInputPublicAssociationSpec payload) returns http:NoContent|http:BadRequest|http:MultiStatus {
+    resource function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/purge
+            (@http:Payload BatchInputPublicAssociationSpec payload)
+    returns http:NoContent|http:BadRequest|http:MultiStatus {
         if payload.inputs[0].typeId == 5 {
             return http:BAD_REQUEST;
         }
         return http:NO_CONTENT;
     }
 
-    resource function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/update(@http:Payload BatchInputPublicAssociationDefinitionConfigurationUpdateRequest payload) returns BatchResponsePublicAssociationDefinitionConfigurationUpdateResult|error {
+    resource function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/update
+            (@http:Payload BatchInputPublicAssociationDefinitionConfigurationUpdateRequest payload)
+    returns BatchResponsePublicAssociationDefinitionConfigurationUpdateResult|error {
         if payload.inputs[0].typeId == 5 {
             return {
                 status: "CANCELED",
@@ -144,7 +156,9 @@ service on new http:Listener(9090) {
         };
     }
 
-    resource function put [string fromObjectType]/[string toObjectType]/labels(@http:Payload PublicAssociationDefinitionUpdateRequest payload) returns http:NoContent|http:BadRequest {
+    resource function put [string fromObjectType]/[string toObjectType]/labels
+            (@http:Payload PublicAssociationDefinitionUpdateRequest payload)
+    returns http:NoContent|http:BadRequest {
         if payload.label == null || payload.associationTypeId == -1 {
             return http:BAD_REQUEST;
         }

--- a/ballerina/tests/mock_service.bal
+++ b/ballerina/tests/mock_service.bal
@@ -20,6 +20,7 @@ service on new http:Listener(9090) {
     resource function delete [string fromObjectType]/[string toObjectType]/labels/[int:Signed32 associationTypeId]() returns http:NoContent|error {
         return http:NO_CONTENT;
     }
+
     resource function get [string fromObjectType]/[string toObjectType]/labels() returns CollectionResponseAssociationSpecWithLabelNoPaging|error {
         return {
             "results": [
@@ -36,6 +37,7 @@ service on new http:Listener(9090) {
             ]
         };
     }
+
     resource function get definitions/configurations/[string fromObjectType]/[string toObjectType]() returns CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging|error {
         return {
             "results": [
@@ -48,6 +50,7 @@ service on new http:Listener(9090) {
             ]
         };
     }
+
     resource function get definitions/configurations/all() returns CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging|error {
         return {
             "results": [
@@ -66,6 +69,7 @@ service on new http:Listener(9090) {
             ]
         };
     }
+
     resource function post [string fromObjectType]/[string toObjectType]/labels(@http:Payload PublicAssociationDefinitionCreateRequest payload) returns CollectionResponseAssociationSpecWithLabelNoPaging|http:BadRequest {
         if payload.label == null {
             return http:BAD_REQUEST;
@@ -85,6 +89,7 @@ service on new http:Listener(9090) {
             ]
         };
     }
+
     resource function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/create(@http:Payload BatchInputPublicAssociationDefinitionConfigurationCreateRequest payload) returns BatchResponsePublicAssociationDefinitionUserConfiguration|error {
         if payload.inputs[0].typeId == -1 {
             return {
@@ -128,12 +133,14 @@ service on new http:Listener(9090) {
             "completedAt": "2025-02-19T05:28:18.911Z"
         };
     }
+
     resource function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/purge(@http:Payload BatchInputPublicAssociationSpec payload) returns http:NoContent|http:BadRequest|http:MultiStatus {
         if payload.inputs[0].typeId == 5 {
             return http:BAD_REQUEST;
         }
         return http:NO_CONTENT;
     }
+
     resource function post definitions/configurations/[string fromObjectType]/[string toObjectType]/batch/update(@http:Payload BatchInputPublicAssociationDefinitionConfigurationUpdateRequest payload) returns BatchResponsePublicAssociationDefinitionConfigurationUpdateResult|error {
         if payload.inputs[0].typeId == 5 {
             return {
@@ -176,6 +183,7 @@ service on new http:Listener(9090) {
             "completedAt": "2025-02-19T05:45:32.957Z"
         };
     }
+
     resource function put [string fromObjectType]/[string toObjectType]/labels(@http:Payload PublicAssociationDefinitionUpdateRequest payload) returns http:NoContent|http:BadRequest {
         if payload.label == null || payload.associationTypeId == -1 {
             return http:BAD_REQUEST;

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -34,6 +34,9 @@ final string inverseLabel = "InverseLabel";
 final string labelName = "LabelName";
 final string labelToUpdate = "LabelNew";
 
+isolated int:Signed32 createdInverseLabelId = -1;
+isolated int:Signed32 createdLabelId = -1;
+
 final int:Signed32 typeId = 4; //association type id for contact to deals association
 
 //init client
@@ -52,10 +55,6 @@ isolated function initClient() returns Client|error {
     }
     return check new Client({auth: {token: "test-token"}}, serviceUrl);
 }
-
-isolated int:Signed32 createdInverseLabelId = -1;
-isolated int:Signed32 createdLabelId = -1;
-
 
 //Association definition Tests
 //Test: Create association definitions

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -217,3 +217,78 @@ isolated function testDeleteAssociationDefinitionConfigurations() returns error?
     test:assertTrue(response.statusCode == 204, msg = "Unexpected behavior for association definition configuration deletion.");
     io:println("Test Passed: Correctly handled association definition configuration deletion.");
 }
+
+//negative test cases
+
+//Test(negative): Update association definition with invalid data
+@test:Config {groups: ["live_test", "mock_test"]}
+isolated function testUpdateAssociationDefinitionsInvalidData() returns error? {
+    io:println("Running test: Update association labels with invalid data...");
+    lock {
+        var response = check baseClient->/[fromObjectType]/[toObjectType]/labels.put(payload = {
+            "associationTypeId": -1, // Invalid associationTypeId
+            "label": "" // Invalid empty label
+        });
+
+        test:assertEquals(response.statusCode, 400, msg = "Unexpected behavior for invalid data.");
+        io:println("Test Passed: Correctly handled invalid data.");
+    }
+}
+
+//Test(negative): Create association definition configuration with invalid data
+@test:Config {groups: ["live_test", "mock_test"]}
+isolated function testCreateAssociationDefinitionConfigurationsInvalidData() returns error? {
+    io:println("Running test: Create association definitions with invalid data...");
+    lock {
+        var response = check baseClient->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/create.post(payload = {
+            "inputs": [
+                {
+                    "typeId": -1, // Invalid associationTypeId
+                    "category": "HUBSPOT_DEFINED",
+                    "maxToObjectIds": 2
+                }
+            ]
+        });
+
+        test:assertEquals(response.status, "CANCELED", msg = "Unexpected behavior for invalid data.");
+        io:println("Test Passed: Correctly handled invalid data.");
+    }
+}
+
+//Test(negative): Update association definition configuration with invalid data
+@test:Config {groups: ["live_test", "mock_test"]}
+isolated function testUpdateAssociationDefinitionConfigurationsInvalidId() returns error? {
+    io:println("Running test: Update association definitions with invalid data...");
+    lock {
+        var response = check baseClient->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/update.post(payload = {
+            "inputs": [
+                {
+                    "typeId": 5, //invalid type id for contact to deals association
+                    "category": "USER_DEFINED",
+                    "maxToObjectIds": 5
+                }
+            ]
+        });
+
+        test:assertEquals(response.status, "CANCELED", msg = "Unexpected behavior for invalid association type id.");
+        io:println("Test Passed: Correctly handled invalid association type id.");
+    }
+}
+
+//Test(negative): Delete association definition configuration with invalid data
+@test:Config {groups: ["live_test", "mock_test"]}
+isolated function testDeleteAssociationDefinitionConfigurationsWithInvalidData() returns error? {
+    io:println("Running test: Delete association definitions...");
+
+    var response = check baseClient->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/purge.post(payload = {
+        "inputs": [
+            {
+                "typeId": 5, //invalid type id for contact to deals association
+                "category": "HUBSPOT_DEFINED"
+            }
+        ]
+    });
+
+    test:assertTrue(response.statusCode == 207 || response.statusCode == 400, msg = "Unexpected behavior for invalid association type id.");
+    io:println("Test Passed: Correctly handled invalid association definition data.");
+}

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -137,3 +137,83 @@ isolated function testDeleteAssociationDefinitions() returns error? {
         io:println("Deleted inverse association definition with ID: " + createdInverseLabelId.toString());
     }
 }
+
+//Association definition Configurations Tests
+//Test: Create association definition Configurations
+@test:Config {groups: ["live_test", "mock_test"]}
+isolated function testCreateAssociationDefinitionConfigurations() returns error? {
+    io:println("Running test: Create association definition Configurations...");
+    CollectionResponseAssociationSpecWithLabelNoPaging response =
+        check baseClient->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/create.post(payload = {
+        "inputs": [
+            {
+                "typeId": typeId,
+                "category": "HUBSPOT_DEFINED",
+                "maxToObjectIds": 2
+            }
+        ]
+    });
+
+    test:assertTrue(response.results.length() > 0, msg = "No definition configurations were created.");
+    test:assertEquals(response.results.length(), 1, msg = "Unexpected behavior on association definition configuration creation.");
+    io:println("Test Passed: Created association definition confgurations: " + response.results.length().toString());
+}
+
+//Test: Read ALL configurations
+@test:Config {dependsOn: [testCreateAssociationDefinitionConfigurations], groups: ["live_test", "mock_test"]}
+isolated function testGetAllDefinitionsConfigurations() returns error? {
+    io:println("Running test: Get all definitions configurations...");
+    CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging response =
+        check baseClient->/definitions/configurations/all.get();
+    test:assertTrue(response.results.length() > 0, msg = "No configurations were returned.");
+    test:assertEquals(response.results.length(), 2, msg = "Unexpected behavior on all configurations retrieval.");
+    io:println("Test Passed: Retrieved all definition configurations: " + response.results.length().toString());
+}
+
+//Test: Read association definition configurations
+@test:Config {dependsOn: [testCreateAssociationDefinitionConfigurations], groups: ["live_test", "mock_test"]}
+isolated function testGetAssociationDefinitionConfigurations() returns error? {
+    io:println("Running test: Get association definition configurations...");
+    CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging response =
+        check baseClient->/definitions/configurations/[fromObjectType]/[toObjectType].get();
+    test:assertTrue(response.results.length() > 0, msg = "No  association definition configurations were returned.");
+    io:println("Test Passed: Retrieved association definition configurations: " + response.results.length().toString());
+}
+
+//Test: Update configurations
+@test:Config {dependsOn: [testCreateAssociationDefinitionConfigurations], groups: ["live_test", "mock_test"]}
+isolated function testUpdateAssociationDefinitionConfigurations() returns error? {
+    io:println("Running test: Update association definition configurations...");
+    lock {
+        var response = check baseClient->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/update.post(payload = {
+            "inputs": [
+                {
+                    "typeId": typeId,
+                    "category": "HUBSPOT_DEFINED",
+                    "maxToObjectIds": 11
+                }
+            ]
+        });
+        test:assertTrue(response.results.length() > 0, msg = "Failed to update association definition configuration.");
+        test:assertEquals(response.status, "COMPLETE", msg = "Unexpected behavior for association definition configuration update.");
+        io:println("Test Passed: Association definition configuration updated successfully.");
+    }
+}
+
+//Test:Delete association definition configurations
+@test:Config {dependsOn: [testUpdateAssociationDefinitionConfigurations], groups: ["live_test", "mock_test"]}
+isolated function testDeleteAssociationDefinitionConfigurations() returns error? {
+    io:println("Running test: Delete association definition configurations...");
+
+    var response = check baseClient->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/purge.post(payload = {
+        "inputs": [
+            {
+                "typeId": typeId,
+                "category": "HUBSPOT_DEFINED"
+            }
+        ]
+    });
+
+    test:assertTrue(response.statusCode == 204, msg = "Unexpected behavior for association definition configuration deletion.");
+    io:println("Test Passed: Correctly handled association definition configuration deletion.");
+}

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -1,0 +1,139 @@
+// Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/oauth2;
+import ballerina/os;
+import ballerina/test;
+
+final boolean isLiveServer = os:getEnv("IS_LIVE_SERVER") == "true";
+final string serviceUrl = isLiveServer ? "https://api.hubapi.com/crm/v4/associations" : "http://localhost:9090";
+
+final string clientId = os:getEnv("HUBSPOT_CLIENT_ID");
+final string clientSecret = os:getEnv("HUBSPOT_CLIENT_SECRET");
+final string refreshToken = os:getEnv("HUBSPOT_REFRESH_TOKEN");
+
+final string fromObjectType = "contacts";
+final string toObjectType = "deals";
+
+final string label = "Label";
+final string inverseLabel = "InverseLabel";
+final string labelName = "LabelName";
+final string labelToUpdate = "LabelNew";
+
+final int:Signed32 typeId = 4; //association type id for contact to deals association
+
+//init client
+final Client baseClient = check initClient();
+
+isolated function initClient() returns Client|error {
+    io:println("Initializing client...");
+    if isLiveServer {
+        OAuth2RefreshTokenGrantConfig auth = {
+            clientId: clientId,
+            clientSecret: clientSecret,
+            refreshToken: refreshToken,
+            credentialBearer: oauth2:POST_BODY_BEARER
+        };
+        return check new Client({auth}, serviceUrl);
+    }
+    return check new Client({auth: {token: "test-token"}}, serviceUrl);
+}
+
+isolated int:Signed32 createdInverseLabelId = -1;
+isolated int:Signed32 createdLabelId = -1;
+
+
+//Association definition Tests
+//Test: Create association definitions
+@test:Config {groups: ["live_test", "mock_test"]}
+isolated function testCreateAssociationDefinitions() returns error? {
+    io:println("Running test: Create association definitions...");
+    CollectionResponseAssociationSpecWithLabelNoPaging response =
+        check baseClient->/[fromObjectType]/[toObjectType]/labels.post(payload = {
+        "label": label,
+        "name": labelName,
+        "inverseLabel": inverseLabel
+    });
+    if response.results.length() > 0 {
+        lock {
+            createdLabelId = response.results[0].typeId;
+        }
+        lock {
+            createdInverseLabelId = response.results[1].typeId;
+        }
+    }
+
+    test:assertTrue(response.results.length() > 0, msg = "No association definitions were created.");
+    test:assertEquals(response.results.length(), 2, msg = "Unexpected behavior on association definition creation.");
+    io:println("Test Passed: Created association definitions: " + response.results.length().toString());
+}
+
+//Test: Update association definitions
+@test:Config {dependsOn: [testCreateAssociationDefinitions], groups: ["live_test", "mock_test"]}
+isolated function testUpdateAssociationDefinitions() returns error? {
+    io:println("Running test: Update association definitions...");
+
+    int response1StatusCode = -1;
+    int response2StatusCode = -1;
+
+    lock {
+        var response1 = check baseClient->/[fromObjectType]/[toObjectType]/labels.put(payload = {
+            "associationTypeId": createdLabelId,
+            "label": labelToUpdate
+        });
+        response1StatusCode = response1.statusCode;
+        io:println("Updated association definition with ID: " + createdLabelId.toString() + " to: " + labelToUpdate);
+    }
+
+    lock {
+        var response2 = check baseClient->/[fromObjectType]/[toObjectType]/labels.put(payload = {
+            "associationTypeId": createdInverseLabelId,
+            "label": labelToUpdate
+        });
+        response2StatusCode = response2.statusCode;
+        io:println("Updated inverse association definition with ID: " + createdInverseLabelId.toString() + " to: " + labelToUpdate);
+    }
+
+    test:assertTrue(response1StatusCode == 204 || response2StatusCode == 204, msg = "Association label update failed for both createdLabelId and createdInverseLabelId");
+}
+
+//Test: Read association definitions
+@test:Config {dependsOn: [testCreateAssociationDefinitions], groups: ["live_test", "mock_test"]}
+isolated function testGetAssociationDefinitions() returns error? {
+    io:println("Running test: Get association definitions...");
+    CollectionResponseAssociationSpecWithLabelNoPaging response =
+        check baseClient->/[fromObjectType]/[toObjectType]/labels.get();
+    test:assertTrue(response.results.length() > 0, msg = "No definitions were returned");
+    test:assertEquals(response.results.length(), 2, msg = "Unexpected behavior on association definition retrieval.");
+    io:println("Test Passed: Retrieved association definitions: " + response.results.length().toString());
+}
+
+//Test: Delete association definitions
+@test:Config {dependsOn: [testGetAssociationDefinitions], groups: ["live_test", "mock_test"]}
+isolated function testDeleteAssociationDefinitions() returns error? {
+    io:println("Running test: Delete association definitions...");
+    lock {
+        var response1 = check baseClient->/[fromObjectType]/[toObjectType]/labels/[createdLabelId].delete();
+        test:assertTrue(response1.statusCode == 204, msg = "Association definition deletion failed");
+        io:println("Deleted association definition with ID: " + createdLabelId.toString());
+    }
+    lock {
+        var response2 = check baseClient->/[fromObjectType]/[toObjectType]/labels/[createdInverseLabelId].delete();
+        test:assertTrue(response2.statusCode == 204, msg = "Association definition deletion failed");
+        io:println("Deleted inverse association definition with ID: " + createdInverseLabelId.toString());
+    }
+}

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -40,7 +40,7 @@ isolated int:Signed32 createdLabelId = -1;
 final int:Signed32 typeId = 4; //association type id for contact to deals association
 
 //init client
-final Client baseClient = check initClient();
+final Client hubspot = check initClient();
 
 isolated function initClient() returns Client|error {
     io:println("Initializing client...");
@@ -62,7 +62,7 @@ isolated function initClient() returns Client|error {
 isolated function testCreateAssociationDefinitions() returns error? {
     io:println("Running test: Create association definitions...");
     CollectionResponseAssociationSpecWithLabelNoPaging response =
-        check baseClient->/[fromObjectType]/[toObjectType]/labels.post(payload = {
+        check hubspot->/[fromObjectType]/[toObjectType]/labels.post(payload = {
         "label": label,
         "name": labelName,
         "inverseLabel": inverseLabel
@@ -90,7 +90,7 @@ isolated function testUpdateAssociationDefinitions() returns error? {
     int response2StatusCode = -1;
 
     lock {
-        var response1 = check baseClient->/[fromObjectType]/[toObjectType]/labels.put(payload = {
+        var response1 = check hubspot->/[fromObjectType]/[toObjectType]/labels.put(payload = {
             "associationTypeId": createdLabelId,
             "label": labelToUpdate
         });
@@ -99,7 +99,7 @@ isolated function testUpdateAssociationDefinitions() returns error? {
     }
 
     lock {
-        var response2 = check baseClient->/[fromObjectType]/[toObjectType]/labels.put(payload = {
+        var response2 = check hubspot->/[fromObjectType]/[toObjectType]/labels.put(payload = {
             "associationTypeId": createdInverseLabelId,
             "label": labelToUpdate
         });
@@ -115,7 +115,7 @@ isolated function testUpdateAssociationDefinitions() returns error? {
 isolated function testGetAssociationDefinitions() returns error? {
     io:println("Running test: Get association definitions...");
     CollectionResponseAssociationSpecWithLabelNoPaging response =
-        check baseClient->/[fromObjectType]/[toObjectType]/labels.get();
+        check hubspot->/[fromObjectType]/[toObjectType]/labels.get();
     test:assertTrue(response.results.length() > 0, msg = "No definitions were returned");
     test:assertEquals(response.results.length(), 2, msg = "Unexpected behavior on association definition retrieval.");
     io:println("Test Passed: Retrieved association definitions: " + response.results.length().toString());
@@ -126,12 +126,12 @@ isolated function testGetAssociationDefinitions() returns error? {
 isolated function testDeleteAssociationDefinitions() returns error? {
     io:println("Running test: Delete association definitions...");
     lock {
-        var response1 = check baseClient->/[fromObjectType]/[toObjectType]/labels/[createdLabelId].delete();
+        var response1 = check hubspot->/[fromObjectType]/[toObjectType]/labels/[createdLabelId].delete();
         test:assertTrue(response1.statusCode == 204, msg = "Association definition deletion failed");
         io:println("Deleted association definition with ID: " + createdLabelId.toString());
     }
     lock {
-        var response2 = check baseClient->/[fromObjectType]/[toObjectType]/labels/[createdInverseLabelId].delete();
+        var response2 = check hubspot->/[fromObjectType]/[toObjectType]/labels/[createdInverseLabelId].delete();
         test:assertTrue(response2.statusCode == 204, msg = "Association definition deletion failed");
         io:println("Deleted inverse association definition with ID: " + createdInverseLabelId.toString());
     }
@@ -143,7 +143,7 @@ isolated function testDeleteAssociationDefinitions() returns error? {
 isolated function testCreateAssociationDefinitionConfigurations() returns error? {
     io:println("Running test: Create association definition Configurations...");
     CollectionResponseAssociationSpecWithLabelNoPaging response =
-        check baseClient->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/create.post(payload = {
+        check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/create.post(payload = {
         "inputs": [
             {
                 "typeId": typeId,
@@ -163,7 +163,7 @@ isolated function testCreateAssociationDefinitionConfigurations() returns error?
 isolated function testGetAllDefinitionsConfigurations() returns error? {
     io:println("Running test: Get all definitions configurations...");
     CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging response =
-        check baseClient->/definitions/configurations/all.get();
+        check hubspot->/definitions/configurations/all.get();
     test:assertTrue(response.results.length() > 0, msg = "No configurations were returned.");
     test:assertEquals(response.results.length(), 2, msg = "Unexpected behavior on all configurations retrieval.");
     io:println("Test Passed: Retrieved all definition configurations: " + response.results.length().toString());
@@ -174,7 +174,7 @@ isolated function testGetAllDefinitionsConfigurations() returns error? {
 isolated function testGetAssociationDefinitionConfigurations() returns error? {
     io:println("Running test: Get association definition configurations...");
     CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging response =
-        check baseClient->/definitions/configurations/[fromObjectType]/[toObjectType].get();
+        check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType].get();
     test:assertTrue(response.results.length() > 0, msg = "No  association definition configurations were returned.");
     io:println("Test Passed: Retrieved association definition configurations: " + response.results.length().toString());
 }
@@ -184,7 +184,7 @@ isolated function testGetAssociationDefinitionConfigurations() returns error? {
 isolated function testUpdateAssociationDefinitionConfigurations() returns error? {
     io:println("Running test: Update association definition configurations...");
     lock {
-        var response = check baseClient->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/update.post(payload = {
+        var response = check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/update.post(payload = {
             "inputs": [
                 {
                     "typeId": typeId,
@@ -204,7 +204,7 @@ isolated function testUpdateAssociationDefinitionConfigurations() returns error?
 isolated function testDeleteAssociationDefinitionConfigurations() returns error? {
     io:println("Running test: Delete association definition configurations...");
 
-    var response = check baseClient->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/purge.post(payload = {
+    var response = check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/purge.post(payload = {
         "inputs": [
             {
                 "typeId": typeId,
@@ -224,7 +224,7 @@ isolated function testDeleteAssociationDefinitionConfigurations() returns error?
 isolated function testUpdateAssociationDefinitionsInvalidData() returns error? {
     io:println("Running test: Update association labels with invalid data...");
     lock {
-        var response = check baseClient->/[fromObjectType]/[toObjectType]/labels.put(payload = {
+        var response = check hubspot->/[fromObjectType]/[toObjectType]/labels.put(payload = {
             "associationTypeId": -1, // Invalid associationTypeId
             "label": "" // Invalid empty label
         });
@@ -239,7 +239,7 @@ isolated function testUpdateAssociationDefinitionsInvalidData() returns error? {
 isolated function testCreateAssociationDefinitionConfigurationsInvalidData() returns error? {
     io:println("Running test: Create association definitions with invalid data...");
     lock {
-        var response = check baseClient->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/create.post(payload = {
+        var response = check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/create.post(payload = {
             "inputs": [
                 {
                     "typeId": -1, // Invalid associationTypeId
@@ -259,7 +259,7 @@ isolated function testCreateAssociationDefinitionConfigurationsInvalidData() ret
 isolated function testUpdateAssociationDefinitionConfigurationsInvalidId() returns error? {
     io:println("Running test: Update association definitions with invalid data...");
     lock {
-        var response = check baseClient->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/update.post(payload = {
+        var response = check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/update.post(payload = {
             "inputs": [
                 {
                     "typeId": 5, //invalid type id for contact to deals association
@@ -279,7 +279,7 @@ isolated function testUpdateAssociationDefinitionConfigurationsInvalidId() retur
 isolated function testDeleteAssociationDefinitionConfigurationsWithInvalidData() returns error? {
     io:println("Running test: Delete association definitions...");
 
-    var response = check baseClient->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/purge.post(payload = {
+    var response = check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/purge.post(payload = {
         "inputs": [
             {
                 "typeId": 5, //invalid type id for contact to deals association

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -127,12 +127,12 @@ isolated function testDeleteAssociationDefinitions() returns error? {
     io:println("Running test: Delete association definitions...");
     lock {
         var response1 = check hubspot->/[fromObjectType]/[toObjectType]/labels/[createdLabelId].delete();
-        test:assertTrue(response1.statusCode == 204, msg = "Association definition deletion failed");
+        test:assertEquals(response1.statusCode, 204 , msg = "Association definition deletion failed");
         io:println("Deleted association definition with ID: " + createdLabelId.toString());
     }
     lock {
         var response2 = check hubspot->/[fromObjectType]/[toObjectType]/labels/[createdInverseLabelId].delete();
-        test:assertTrue(response2.statusCode == 204, msg = "Association definition deletion failed");
+        test:assertEquals(response2.statusCode, 204, msg = "Association definition deletion failed");
         io:println("Deleted inverse association definition with ID: " + createdInverseLabelId.toString());
     }
 }
@@ -213,7 +213,7 @@ isolated function testDeleteAssociationDefinitionConfigurations() returns error?
         ]
     });
 
-    test:assertTrue(response.statusCode == 204, msg = "Unexpected behavior for association definition configuration deletion.");
+    test:assertEquals(response.statusCode, 204, msg = "Unexpected behavior for association definition configuration deletion.");
     io:println("Test Passed: Correctly handled association definition configuration deletion.");
 }
 

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -14,7 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/io;
 import ballerina/oauth2;
 import ballerina/os;
 import ballerina/test;
@@ -43,7 +42,6 @@ final int:Signed32 typeId = 4; //association type id for contact to deals associ
 final Client hubspot = check initClient();
 
 isolated function initClient() returns Client|error {
-    io:println("Initializing client...");
     if isLiveServer {
         OAuth2RefreshTokenGrantConfig auth = {
             clientId: clientId,
@@ -60,7 +58,6 @@ isolated function initClient() returns Client|error {
 //Test: Create association definitions
 @test:Config {groups: ["live_test", "mock_test"]}
 isolated function testCreateAssociationDefinitions() returns error? {
-    io:println("Running test: Create association definitions...");
     CollectionResponseAssociationSpecWithLabelNoPaging response =
         check hubspot->/[fromObjectType]/[toObjectType]/labels.post(payload = {
         "label": label,
@@ -78,13 +75,11 @@ isolated function testCreateAssociationDefinitions() returns error? {
 
     test:assertTrue(response.results.length() > 0, msg = "No association definitions were created.");
     test:assertEquals(response.results.length(), 2, msg = "Unexpected behavior on association definition creation.");
-    io:println("Test Passed: Created association definitions: " + response.results.length().toString());
 }
 
 //Test: Update association definitions
 @test:Config {dependsOn: [testCreateAssociationDefinitions], groups: ["live_test", "mock_test"]}
 isolated function testUpdateAssociationDefinitions() returns error? {
-    io:println("Running test: Update association definitions...");
 
     int response1StatusCode = -1;
     int response2StatusCode = -1;
@@ -95,7 +90,6 @@ isolated function testUpdateAssociationDefinitions() returns error? {
             "label": labelToUpdate
         });
         response1StatusCode = response1.statusCode;
-        io:println("Updated association definition with ID: " + createdLabelId.toString() + " to: " + labelToUpdate);
     }
 
     lock {
@@ -104,7 +98,6 @@ isolated function testUpdateAssociationDefinitions() returns error? {
             "label": labelToUpdate
         });
         response2StatusCode = response2.statusCode;
-        io:println("Updated inverse association definition with ID: " + createdInverseLabelId.toString() + " to: " + labelToUpdate);
     }
 
     test:assertTrue(response1StatusCode == 204 || response2StatusCode == 204, msg = "Association label update failed for both createdLabelId and createdInverseLabelId");
@@ -113,27 +106,22 @@ isolated function testUpdateAssociationDefinitions() returns error? {
 //Test: Read association definitions
 @test:Config {dependsOn: [testCreateAssociationDefinitions], groups: ["live_test", "mock_test"]}
 isolated function testGetAssociationDefinitions() returns error? {
-    io:println("Running test: Get association definitions...");
     CollectionResponseAssociationSpecWithLabelNoPaging response =
         check hubspot->/[fromObjectType]/[toObjectType]/labels.get();
     test:assertTrue(response.results.length() > 0, msg = "No definitions were returned");
     test:assertEquals(response.results.length(), 2, msg = "Unexpected behavior on association definition retrieval.");
-    io:println("Test Passed: Retrieved association definitions: " + response.results.length().toString());
 }
 
 //Test: Delete association definitions
 @test:Config {dependsOn: [testGetAssociationDefinitions], groups: ["live_test", "mock_test"]}
 isolated function testDeleteAssociationDefinitions() returns error? {
-    io:println("Running test: Delete association definitions...");
     lock {
         var response1 = check hubspot->/[fromObjectType]/[toObjectType]/labels/[createdLabelId].delete();
         test:assertEquals(response1.statusCode, 204 , msg = "Association definition deletion failed");
-        io:println("Deleted association definition with ID: " + createdLabelId.toString());
     }
     lock {
         var response2 = check hubspot->/[fromObjectType]/[toObjectType]/labels/[createdInverseLabelId].delete();
         test:assertEquals(response2.statusCode, 204, msg = "Association definition deletion failed");
-        io:println("Deleted inverse association definition with ID: " + createdInverseLabelId.toString());
     }
 }
 
@@ -141,7 +129,6 @@ isolated function testDeleteAssociationDefinitions() returns error? {
 //Test: Create association definition Configurations
 @test:Config {groups: ["live_test", "mock_test"]}
 isolated function testCreateAssociationDefinitionConfigurations() returns error? {
-    io:println("Running test: Create association definition Configurations...");
     CollectionResponseAssociationSpecWithLabelNoPaging response =
         check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/create.post(payload = {
         "inputs": [
@@ -155,34 +142,28 @@ isolated function testCreateAssociationDefinitionConfigurations() returns error?
 
     test:assertTrue(response.results.length() > 0, msg = "No definition configurations were created.");
     test:assertEquals(response.results.length(), 1, msg = "Unexpected behavior on association definition configuration creation.");
-    io:println("Test Passed: Created association definition confgurations: " + response.results.length().toString());
 }
 
 //Test: Read ALL configurations
 @test:Config {dependsOn: [testCreateAssociationDefinitionConfigurations], groups: ["live_test", "mock_test"]}
 isolated function testGetAllDefinitionsConfigurations() returns error? {
-    io:println("Running test: Get all definitions configurations...");
     CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging response =
         check hubspot->/definitions/configurations/all.get();
     test:assertTrue(response.results.length() > 0, msg = "No configurations were returned.");
     test:assertEquals(response.results.length(), 2, msg = "Unexpected behavior on all configurations retrieval.");
-    io:println("Test Passed: Retrieved all definition configurations: " + response.results.length().toString());
 }
 
 //Test: Read association definition configurations
 @test:Config {dependsOn: [testCreateAssociationDefinitionConfigurations], groups: ["live_test", "mock_test"]}
 isolated function testGetAssociationDefinitionConfigurations() returns error? {
-    io:println("Running test: Get association definition configurations...");
     CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging response =
         check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType].get();
     test:assertTrue(response.results.length() > 0, msg = "No  association definition configurations were returned.");
-    io:println("Test Passed: Retrieved association definition configurations: " + response.results.length().toString());
 }
 
 //Test: Update configurations
 @test:Config {dependsOn: [testCreateAssociationDefinitionConfigurations], groups: ["live_test", "mock_test"]}
 isolated function testUpdateAssociationDefinitionConfigurations() returns error? {
-    io:println("Running test: Update association definition configurations...");
     lock {
         var response = check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/update.post(payload = {
             "inputs": [
@@ -195,15 +176,12 @@ isolated function testUpdateAssociationDefinitionConfigurations() returns error?
         });
         test:assertTrue(response.results.length() > 0, msg = "Failed to update association definition configuration.");
         test:assertEquals(response.status, "COMPLETE", msg = "Unexpected behavior for association definition configuration update.");
-        io:println("Test Passed: Association definition configuration updated successfully.");
     }
 }
 
 //Test:Delete association definition configurations
 @test:Config {dependsOn: [testUpdateAssociationDefinitionConfigurations], groups: ["live_test", "mock_test"]}
 isolated function testDeleteAssociationDefinitionConfigurations() returns error? {
-    io:println("Running test: Delete association definition configurations...");
-
     var response = check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/purge.post(payload = {
         "inputs": [
             {
@@ -214,15 +192,12 @@ isolated function testDeleteAssociationDefinitionConfigurations() returns error?
     });
 
     test:assertEquals(response.statusCode, 204, msg = "Unexpected behavior for association definition configuration deletion.");
-    io:println("Test Passed: Correctly handled association definition configuration deletion.");
 }
 
 //negative test cases
-
 //Test(negative): Update association definition with invalid data
 @test:Config {groups: ["live_test", "mock_test"]}
 isolated function testUpdateAssociationDefinitionsInvalidData() returns error? {
-    io:println("Running test: Update association labels with invalid data...");
     lock {
         var response = check hubspot->/[fromObjectType]/[toObjectType]/labels.put(payload = {
             "associationTypeId": -1, // Invalid associationTypeId
@@ -230,14 +205,12 @@ isolated function testUpdateAssociationDefinitionsInvalidData() returns error? {
         });
 
         test:assertEquals(response.statusCode, 400, msg = "Unexpected behavior for invalid data.");
-        io:println("Test Passed: Correctly handled invalid data.");
     }
 }
 
 //Test(negative): Create association definition configuration with invalid data
 @test:Config {groups: ["live_test", "mock_test"]}
 isolated function testCreateAssociationDefinitionConfigurationsInvalidData() returns error? {
-    io:println("Running test: Create association definitions with invalid data...");
     lock {
         var response = check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/create.post(payload = {
             "inputs": [
@@ -250,14 +223,12 @@ isolated function testCreateAssociationDefinitionConfigurationsInvalidData() ret
         });
 
         test:assertEquals(response.status, "CANCELED", msg = "Unexpected behavior for invalid data.");
-        io:println("Test Passed: Correctly handled invalid data.");
     }
 }
 
 //Test(negative): Update association definition configuration with invalid data
 @test:Config {groups: ["live_test", "mock_test"]}
 isolated function testUpdateAssociationDefinitionConfigurationsInvalidId() returns error? {
-    io:println("Running test: Update association definitions with invalid data...");
     lock {
         var response = check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/update.post(payload = {
             "inputs": [
@@ -270,15 +241,12 @@ isolated function testUpdateAssociationDefinitionConfigurationsInvalidId() retur
         });
 
         test:assertEquals(response.status, "CANCELED", msg = "Unexpected behavior for invalid association type id.");
-        io:println("Test Passed: Correctly handled invalid association type id.");
     }
 }
 
 //Test(negative): Delete association definition configuration with invalid data
 @test:Config {groups: ["live_test", "mock_test"]}
 isolated function testDeleteAssociationDefinitionConfigurationsWithInvalidData() returns error? {
-    io:println("Running test: Delete association definitions...");
-
     var response = check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/purge.post(payload = {
         "inputs": [
             {
@@ -289,5 +257,4 @@ isolated function testDeleteAssociationDefinitionConfigurationsWithInvalidData()
     });
 
     test:assertTrue(response.statusCode == 207 || response.statusCode == 400, msg = "Unexpected behavior for invalid association type id.");
-    io:println("Test Passed: Correctly handled invalid association definition data.");
 }

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -20,7 +20,8 @@ import ballerina/os;
 import ballerina/test;
 
 final boolean isLiveServer = os:getEnv("IS_LIVE_SERVER") == "true";
-final string serviceUrl = isLiveServer ? "https://api.hubapi.com/crm/v4/associations" : "http://localhost:9090";
+final string serviceUrl = isLiveServer ? "https://api.hubapi.com/crm/v4/associations" :
+    "http://localhost:9090";
 
 final string clientId = os:getEnv("HUBSPOT_CLIENT_ID");
 final string clientSecret = os:getEnv("HUBSPOT_CLIENT_SECRET");
@@ -36,7 +37,6 @@ final string labelToUpdate = "LabelNew";
 
 isolated int:Signed32 createdInverseLabelId = -1;
 isolated int:Signed32 createdLabelId = -1;
-
 final int:Signed32 typeId = 4; //association type id for contact to deals association
 
 //init client
@@ -74,15 +74,15 @@ isolated function testCreateAssociationDefinitions() returns error? {
             createdInverseLabelId = response.results[1].typeId;
         }
     }
-
-    test:assertTrue(response.results.length() > 0, msg = "No association definitions were created.");
-    test:assertEquals(response.results.length(), 2, msg = "Unexpected behavior on association definition creation.");
+    test:assertTrue(response.results.length() > 0, msg =
+            "No association definitions were created.");
+    test:assertEquals(response.results.length(), 2, msg =
+            "Unexpected behavior on association definition creation.");
 }
 
 //Test: Update association definitions
 @test:Config {dependsOn: [testCreateAssociationDefinitions], groups: ["live_test", "mock_test"]}
 isolated function testUpdateAssociationDefinitions() returns error? {
-
     int response1StatusCode = -1;
     int response2StatusCode = -1;
     lock {
@@ -90,21 +90,21 @@ isolated function testUpdateAssociationDefinitions() returns error? {
             associationTypeId: createdLabelId,
             label: labelToUpdate
         };
-
-        http:Response response1 = check hubspot->/[fromObjectType]/[toObjectType]/labels.put(payload);
+        http:Response response1 =
+        check hubspot->/[fromObjectType]/[toObjectType]/labels.put(payload);
         response1StatusCode = response1.statusCode;
     }
-
     lock {
         PublicAssociationDefinitionUpdateRequest payload = {
             associationTypeId: createdInverseLabelId,
             label: labelToUpdate
         };
-        http:Response response2 = check hubspot->/[fromObjectType]/[toObjectType]/labels.put(payload);
+        http:Response response2 =
+        check hubspot->/[fromObjectType]/[toObjectType]/labels.put(payload);
         response2StatusCode = response2.statusCode;
     }
-
-    test:assertTrue(response1StatusCode == 204 || response2StatusCode == 204, msg = "Association label update failed for both createdLabelId and createdInverseLabelId");
+    test:assertTrue(response1StatusCode == 204 || response2StatusCode == 204,
+            msg = "Association label update failed for both createdLabelId and createdInverseLabelId");
 }
 
 //Test: Read association definitions
@@ -112,8 +112,10 @@ isolated function testUpdateAssociationDefinitions() returns error? {
 isolated function testGetAssociationDefinitions() returns error? {
     CollectionResponseAssociationSpecWithLabelNoPaging response =
         check hubspot->/[fromObjectType]/[toObjectType]/labels.get();
-    test:assertTrue(response.results.length() > 0, msg = "No definitions were returned");
-    test:assertEquals(response.results.length(), 2, msg = "Unexpected behavior on association definition retrieval.");
+    test:assertTrue(response.results.length() > 0,
+            msg = "No definitions were returned");
+    test:assertEquals(response.results.length(), 2,
+            msg = "Unexpected behavior on association definition retrieval.");
 }
 
 //Test: Delete association definitions
@@ -124,7 +126,8 @@ isolated function testDeleteAssociationDefinitions() returns error? {
         test:assertEquals(response1.statusCode, 204, msg = "Association definition deletion failed");
     }
     lock {
-        http:Response response2 = check hubspot->/[fromObjectType]/[toObjectType]/labels/[createdInverseLabelId].delete();
+        http:Response response2 =
+            check hubspot->/[fromObjectType]/[toObjectType]/labels/[createdInverseLabelId].delete();
         test:assertEquals(response2.statusCode, 204, msg = "Association definition deletion failed");
     }
 }
@@ -144,9 +147,10 @@ isolated function testCreateAssociationDefinitionConfigurations() returns error?
     };
     CollectionResponseAssociationSpecWithLabelNoPaging response =
         check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/create.post(payload);
-
-    test:assertTrue(response.results.length() > 0, msg = "No definition configurations were created.");
-    test:assertEquals(response.results.length(), 1, msg = "Unexpected behavior on association definition configuration creation.");
+    test:assertTrue(response.results.length() > 0, msg =
+            "No definition configurations were created.");
+    test:assertEquals(response.results.length(), 1, msg =
+            "Unexpected behavior on definition configuration creation.");
 }
 
 //Test: Read ALL configurations
@@ -154,8 +158,10 @@ isolated function testCreateAssociationDefinitionConfigurations() returns error?
 isolated function testGetAllDefinitionsConfigurations() returns error? {
     CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging response =
         check hubspot->/definitions/configurations/all.get();
-    test:assertTrue(response.results.length() > 0, msg = "No configurations were returned.");
-    test:assertEquals(response.results.length(), 2, msg = "Unexpected behavior on all configurations retrieval.");
+    test:assertTrue(response.results.length() > 0,
+            msg = "No configurations were returned.");
+    test:assertEquals(response.results.length(), 2,
+            msg = "Unexpected behavior on all configurations retrieval.");
 }
 
 //Test: Read association definition configurations
@@ -163,26 +169,28 @@ isolated function testGetAllDefinitionsConfigurations() returns error? {
 isolated function testGetAssociationDefinitionConfigurations() returns error? {
     CollectionResponsePublicAssociationDefinitionUserConfigurationNoPaging response =
         check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType].get();
-    test:assertTrue(response.results.length() > 0, msg = "No  association definition configurations were returned.");
+    test:assertTrue(response.results.length() > 0, msg =
+            "No  association definition configurations were returned.");
 }
 
 //Test: Update configurations
 @test:Config {dependsOn: [testCreateAssociationDefinitionConfigurations], groups: ["live_test", "mock_test"]}
 isolated function testUpdateAssociationDefinitionConfigurations() returns error? {
-    lock {
-        BatchInputPublicAssociationDefinitionConfigurationUpdateRequest payload = {
-            inputs: [
-                {
-                    typeId: typeId,
-                    category: "HUBSPOT_DEFINED",
-                    maxToObjectIds: 11
-                }
-            ]
-        };
-        BatchResponsePublicAssociationDefinitionConfigurationUpdateResult response = check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/update.post(payload);
-        test:assertTrue(response.results.length() > 0, msg = "Failed to update association definition configuration.");
-        test:assertEquals(response.status, "COMPLETE", msg = "Unexpected behavior for association definition configuration update.");
-    }
+    BatchInputPublicAssociationDefinitionConfigurationUpdateRequest payload = {
+        inputs: [
+            {
+                typeId: typeId,
+                category: "HUBSPOT_DEFINED",
+                maxToObjectIds: 11
+            }
+        ]
+    };
+    BatchResponsePublicAssociationDefinitionConfigurationUpdateResult response =
+        check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/update.post(payload);
+    test:assertTrue(response.results.length() > 0,
+            msg = "Failed to update association definition configuration.");
+    test:assertEquals(response.status, "COMPLETE",
+            msg = "Unexpected behavior for definition configuration update.");
 }
 
 //Test:Delete association definition configurations
@@ -196,62 +204,58 @@ isolated function testDeleteAssociationDefinitionConfigurations() returns error?
             }
         ]
     };
-    http:Response response = check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/purge.post(payload);
+    http:Response response =
+    check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/purge.post(payload);
 
-    test:assertEquals(response.statusCode, 204, msg = "Unexpected behavior for association definition configuration deletion.");
+    test:assertEquals(response.statusCode, 204,
+            msg = "Unexpected behavior for definition configuration deletion.");
 }
 
 //negative test cases
 //Test(negative): Update association definition with invalid data
 @test:Config {groups: ["live_test", "mock_test"]}
 isolated function testUpdateAssociationDefinitionsInvalidData() returns error? {
-    lock {
-        PublicAssociationDefinitionUpdateRequest payload = {
-            associationTypeId: -1, // Invalid associationTypeId
-            label: "" // Invalid empty label
-        };
-        http:Response response = check hubspot->/[fromObjectType]/[toObjectType]/labels.put(payload);
-
-        test:assertEquals(response.statusCode, 400, msg = "Unexpected behavior for invalid data.");
-    }
+    PublicAssociationDefinitionUpdateRequest payload = {
+        associationTypeId: -1, // Invalid associationTypeId
+        label: "" // Invalid empty label
+    };
+    http:Response response = check hubspot->/[fromObjectType]/[toObjectType]/labels.put(payload);
+    test:assertEquals(response.statusCode, 400, msg = "Unexpected behavior for invalid data.");
 }
 
 //Test(negative): Create association definition configuration with invalid data
 @test:Config {groups: ["live_test", "mock_test"]}
 isolated function testCreateAssociationDefinitionConfigurationsInvalidData() returns error? {
-    lock {
-        BatchInputPublicAssociationDefinitionConfigurationCreateRequest payload = {
-            inputs: [
-                {
-                    typeId: -1, // Invalid associationTypeId
-                    category: "HUBSPOT_DEFINED",
-                    maxToObjectIds: 2
-                }
-            ]
-        };
-        BatchResponsePublicAssociationDefinitionUserConfiguration response = check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/create.post(payload);
-
-        test:assertEquals(response.status, "CANCELED", msg = "Unexpected behavior for invalid data.");
-    }
+    BatchInputPublicAssociationDefinitionConfigurationCreateRequest payload = {
+        inputs: [
+            {
+                typeId: -1, // Invalid associationTypeId
+                category: "HUBSPOT_DEFINED",
+                maxToObjectIds: 2
+            }
+        ]
+    };
+    BatchResponsePublicAssociationDefinitionUserConfiguration response =
+        check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/create.post(payload);
+    test:assertEquals(response.status, "CANCELED", msg = "Unexpected behavior for invalid data.");
 }
 
 //Test(negative): Update association definition configuration with invalid data
 @test:Config {groups: ["live_test", "mock_test"]}
 isolated function testUpdateAssociationDefinitionConfigurationsInvalidId() returns error? {
-    lock {
-        BatchInputPublicAssociationDefinitionConfigurationUpdateRequest payload = {
-            inputs: [
-                {
-                    typeId: 5, //invalid type id for contact to deals association
-                    category: "USER_DEFINED",
-                    maxToObjectIds: 5
-                }
-            ]
-        };
-        BatchResponsePublicAssociationDefinitionConfigurationUpdateResult response = check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/update.post(payload);
-
-        test:assertEquals(response.status, "CANCELED", msg = "Unexpected behavior for invalid association type id.");
-    }
+    BatchInputPublicAssociationDefinitionConfigurationUpdateRequest payload = {
+        inputs: [
+            {
+                typeId: 5, //invalid type id for contact to deals association
+                category: "USER_DEFINED",
+                maxToObjectIds: 5
+            }
+        ]
+    };
+    BatchResponsePublicAssociationDefinitionConfigurationUpdateResult response =
+        check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/update.post(payload);
+    test:assertEquals(response.status, "CANCELED",
+            msg = "Unexpected behavior for invalid association type id.");
 }
 
 //Test(negative): Delete association definition configuration with invalid data
@@ -265,7 +269,8 @@ isolated function testDeleteAssociationDefinitionConfigurationsWithInvalidData()
             }
         ]
     };
-    http:Response response = check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/purge.post(payload);
-
-    test:assertTrue(response.statusCode == 207 || response.statusCode == 400, msg = "Unexpected behavior for invalid association type id.");
+    http:Response response =
+    check hubspot->/definitions/configurations/[fromObjectType]/[toObjectType]/batch/purge.post(payload);
+    test:assertTrue(response.statusCode == 207 || response.statusCode == 400,
+            msg = "Unexpected behavior for invalid association type id.");
 }

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -14,10 +14,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/http;
 import ballerina/oauth2;
 import ballerina/os;
 import ballerina/test;
-import ballerina/http;
 
 final boolean isLiveServer = os:getEnv("IS_LIVE_SERVER") == "true";
 final string serviceUrl = isLiveServer ? "https://api.hubapi.com/crm/v4/associations" : "http://localhost:9090";
@@ -59,10 +59,11 @@ isolated function initClient() returns Client|error {
 //Test: Create association definitions
 @test:Config {groups: ["live_test", "mock_test"]}
 isolated function testCreateAssociationDefinitions() returns error? {
-      PublicAssociationDefinitionCreateRequest payload = {
+    PublicAssociationDefinitionCreateRequest payload = {
         inverseLabel: inverseLabel,
         name: labelName,
-        label: label};
+        label: label
+    };
     CollectionResponseAssociationSpecWithLabelNoPaging response =
         check hubspot->/[fromObjectType]/[toObjectType]/labels.post(payload);
     if response.results.length() > 0 {
@@ -84,12 +85,12 @@ isolated function testUpdateAssociationDefinitions() returns error? {
 
     int response1StatusCode = -1;
     int response2StatusCode = -1;
-    lock{
-    PublicAssociationDefinitionUpdateRequest payload = {
-        associationTypeId: createdLabelId,
-        label: labelToUpdate
-    };
-    
+    lock {
+        PublicAssociationDefinitionUpdateRequest payload = {
+            associationTypeId: createdLabelId,
+            label: labelToUpdate
+        };
+
         http:Response response1 = check hubspot->/[fromObjectType]/[toObjectType]/labels.put(payload);
         response1StatusCode = response1.statusCode;
     }
@@ -120,7 +121,7 @@ isolated function testGetAssociationDefinitions() returns error? {
 isolated function testDeleteAssociationDefinitions() returns error? {
     lock {
         http:Response response1 = check hubspot->/[fromObjectType]/[toObjectType]/labels/[createdLabelId].delete();
-        test:assertEquals(response1.statusCode, 204 , msg = "Association definition deletion failed");
+        test:assertEquals(response1.statusCode, 204, msg = "Association definition deletion failed");
     }
     lock {
         http:Response response2 = check hubspot->/[fromObjectType]/[toObjectType]/labels/[createdInverseLabelId].delete();
@@ -241,7 +242,7 @@ isolated function testUpdateAssociationDefinitionConfigurationsInvalidId() retur
         BatchInputPublicAssociationDefinitionConfigurationUpdateRequest payload = {
             inputs: [
                 {
-                    typeId: 5,//invalid type id for contact to deals association
+                    typeId: 5, //invalid type id for contact to deals association
                     category: "USER_DEFINED",
                     maxToObjectIds: 5
                 }

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -33,7 +33,7 @@ public type BatchResponsePublicAssociationDefinitionUserConfigurationWithErrors 
 public type PublicAssociationDefinitionCreateRequest record {
     string inverseLabel?;
     string name;
-    string label;
+    string? label;
 };
 
 public type StandardError record {
@@ -98,7 +98,7 @@ public type ProxyConfig record {|
 public type PublicAssociationDefinitionUpdateRequest record {
     string inverseLabel?;
     int:Signed32 associationTypeId;
-    string label;
+    string? label;
 };
 
 public type ErrorDetail record {
@@ -116,7 +116,7 @@ public type ErrorDetail record {
 
 public type AssociationSpecWithLabel record {
     int:Signed32 typeId;
-    string label?;
+    string? label?;
     "HUBSPOT_DEFINED"|"USER_DEFINED"|"INTEGRATOR_DEFINED" category;
 };
 
@@ -125,9 +125,9 @@ public type CollectionResponseAssociationSpecWithLabelNoPaging record {
 };
 
 public type PublicAssociationDefinitionUserConfiguration record {
-    int:Signed32 userEnforcedMaxToObjectIds?;
+    int:Signed32? userEnforcedMaxToObjectIds?;
     int:Signed32 typeId;
-    string label?;
+    string? label?;
     "HUBSPOT_DEFINED"|"USER_DEFINED"|"INTEGRATOR_DEFINED" category;
 };
 

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -2,11 +2,11 @@
 distribution = "2201.11.0"
 org = "ballerinax"
 name = "hubspot.crm.associations.schema"
-version = "@toml.version@"
+version = "1.0.0"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
-keywords = [] # TODO: Add keywords
-# icon = "icon.png" # TODO: Add icon
+keywords = ["hubspot" ,"crm" ,"associations" ,"schema"]
+#icon = "icon.png"
 repository = "https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.associations.schema"
 
 [build-options]

--- a/docs/spec/openapi.json
+++ b/docs/spec/openapi.json
@@ -1870,7 +1870,8 @@
             "type" : "string"
           },
           "label" : {
-            "type" : "string"
+            "type" : "string",
+            "nullable": true
           }
         }
       },
@@ -2106,7 +2107,8 @@
             "format" : "int32"
           },
           "label" : {
-            "type" : "string"
+            "type" : "string",
+            "nullable": true
           }
         }
       },
@@ -2154,7 +2156,8 @@
             "format" : "int32"
           },
           "label" : {
-            "type" : "string"
+            "type" : "string",
+            "nullable":true
           },
           "category" : {
             "type" : "string",
@@ -2180,14 +2183,16 @@
         "properties" : {
           "userEnforcedMaxToObjectIds" : {
             "type" : "integer",
-            "format" : "int32"
+            "format" : "int32",
+            "nullable": true
           },
           "typeId" : {
             "type" : "integer",
             "format" : "int32"
           },
           "label" : {
-            "type" : "string"
+            "type" : "string",
+            "nullable": true
           },
           "category" : {
             "type" : "string",

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -47,15 +47,16 @@ These changes are done in order to improve the overall usability, and as workaro
 
   ```json
     "PublicAssociationDefinitionUserConfiguration" : {
-        "properties" : {
-          "userEnforcedMaxToObjectIds" : {
-            "type" : "integer",
-            "format" : "int32",
-          },
-          "label" : {
-            "type" : "string"
-          }
-    }}
+      "properties" : {
+        "userEnforcedMaxToObjectIds" : {
+          "type" : "integer",
+          "format" : "int32",
+        },
+        "label" : {
+          "type" : "string"
+        }
+      }
+    }
   ```
 
 - **Updated**:
@@ -72,7 +73,8 @@ These changes are done in order to improve the overall usability, and as workaro
             "type" : "string",
             "nullable": true
           }
-     }}
+       }
+     }
   ```
 
 - **Reason**: The properties `userEnforcedMaxToObjectIds` and `label` are updated to be nullable, meaning they can either hold their respective values or be null, to fix a payload binding error.
@@ -130,7 +132,7 @@ These changes are done in order to improve the overall usability, and as workaro
             "nullable":true
           }
         }
-    }
+      }
   ```
 
 - **Reason**: The property `label` is updated to be nullable, meaning it can either hold its respective values or be null, to fix a payload binding error.

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -9,7 +9,7 @@ This document records the sanitation done on top of the official OpenAPI specifi
 The OpenAPI specification is obtained from [Hubspot API Reference](https://github.com/HubSpot/HubSpot-public-api-spec-collection/blob/main/PublicApiSpecs/CRM/Associations%20Schema/Rollouts/130902/v4/associationsSchema.json).
 These changes are done in order to improve the overall usability, and as workarounds for some known language limitations.
 
-1. Changed the `url` property of the servers object
+1. Change the `url` property of the servers object
 
 - **Original**:
 `https://api.hubspot.com`
@@ -19,13 +19,13 @@ These changes are done in order to improve the overall usability, and as workaro
 
 - **Reason**: This change of adding the common prefix `crm/v4/associations` to the base url makes it easier to access endpoints using the client and also eliminates redundancy.
 
-2. Updated the API Paths
+2. Update the API Paths
 
 - **Original**: Paths included common prefix above in each endpoint. (eg: `/crm/v4/associations`)
 - **Updated**: Common prefix is now removed from the endpoints as it is included in the base URL.
 - **Reason**: This change simplifies the API paths, making them shorter and more readable.
 
-3. Updated the `date-time` into `datetime` to make it compatible with the Ballerina type conversions.
+3. Update the `date-time` into `datetime` to make it compatible with the Ballerina type conversions.
 
 - **Original**:
 
@@ -41,7 +41,7 @@ These changes are done in order to improve the overall usability, and as workaro
 
 - **Reason**: The `date-time` format is not compatible with the OpenAPI tool. Therefore, it is updated to `datetime` to make it compatible with the tool.
 
-4. Updated the `label` and `userEnforcedMaxToObjectIds` properties in `PublicAssociationDefinitionUserConfiguration` to support nullable values.
+4. Update the `label` and `userEnforcedMaxToObjectIds` properties in `PublicAssociationDefinitionUserConfiguration` to support nullable values.
 
 - **Original**:
 
@@ -79,7 +79,7 @@ These changes are done in order to improve the overall usability, and as workaro
 
 - **Reason**: The properties `userEnforcedMaxToObjectIds` and `label` are updated to be nullable, meaning they can either hold their respective values or be null, to fix a payload binding error.
 
-5. Updated the `label` property in `PublicAssociationDefinitionCreateRequest` to suppoert nullable values.
+5. Update the `label` property in `PublicAssociationDefinitionCreateRequest` to suppoert nullable values.
 
 - **Original**:
 
@@ -108,7 +108,7 @@ These changes are done in order to improve the overall usability, and as workaro
 
 - **Reason**: The property `label` is updated to be nullable, meaning it can either hold its respective values or be null, to fix a payload binding error.
 
-6. Updated the `label` property in `AssociationSpecWithLabel` to support nullable values
+6. Update the `label` property in `AssociationSpecWithLabel` to support nullable values
 
 - **Original**:  
 
@@ -137,7 +137,7 @@ These changes are done in order to improve the overall usability, and as workaro
 
 - **Reason**: The property `label` is updated to be nullable, meaning it can either hold its respective values or be null, to fix a payload binding error.
 
-7. Updated the `label` property in `PublicAssociationDefinitionUpdateRequest` to support nullable values.
+7. Update the `label` property in `PublicAssociationDefinitionUpdateRequest` to support nullable values.
 
 - **Original**:
 

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -31,6 +31,142 @@ These changes are done in order to improve the overall usability, and as workaro
 - **Updated**: `"format": "datetime"`
 - **Reason**: The `date-time` format is not compatible with the OpenAPI tool. Therefore, it is updated to `datetime` to make it compatible with the tool.
 
+4. Make `"label"`,`"userEnforcedMaxToObjectIds"` properties in `"PublicAssociationDefinitionUserConfiguration"` object nullable
+
+- **Original**:
+    "PublicAssociationDefinitionUserConfiguration" : {
+        ...
+        "properties" : {
+          "userEnforcedMaxToObjectIds" : {
+            "type" : "integer",
+            "format" : "int32",
+          },
+         .
+         .
+          "label" : {
+            "type" : "string"
+          },
+          .
+          .
+    }},
+
+- **Updated**:
+     "PublicAssociationDefinitionUserConfiguration" : {
+        "properties" : {
+          "userEnforcedMaxToObjectIds" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable": true
+          },
+         .
+         .
+          "label" : {
+            "type" : "string",
+            "nullable": true
+          },
+          .
+          .
+     }},
+
+- **Reason**: The properties `"userEnforcedMaxToObjectIds"` and `"label"` are updated to be nullable, meaning they can either hold their respective values or be null, to fix payload binding error.
+
+5. Make `"label"` property in `"PublicAssociationDefinitionCreateRequest"` object nullable
+
+- **Original**:  
+     "PublicAssociationDefinitionCreateRequest" : {
+        .
+        .
+        "properties" : {
+          .
+          .
+          "label" : {
+            "type" : "string"
+          }
+        }
+      },
+
+- **Updated**:
+     "PublicAssociationDefinitionCreateRequest" : {
+        .
+        .
+        "properties" : {
+          .
+          .
+          "label" : {
+            "type" : "string",
+            "nullable": true
+          }
+        }
+      },
+
+- **Reason**: The property `"label"` is updated to be nullable, meaning it can either hold its respective values or be null, to fix payload binding error.
+
+6. Make `"label"` property in `"AssociationSpecWithLabel"` object nullable
+
+- **Original**:  
+      "AssociationSpecWithLabel" : {
+        .
+        .
+        "properties" : {
+          .
+          .
+          "label" : {
+            "type" : "string"
+          },
+          .
+          .
+        }
+      },
+
+- **Updated**:
+      "AssociationSpecWithLabel" : {
+        .
+        .
+        "properties" : {
+          .
+          .
+          "label" : {
+            "type" : "string",
+            "nullable":true
+          },
+          .
+          .
+        }
+      },
+
+- **Reason**: The property `"label"` is updated to be nullable, meaning it can either hold its respective values or be null, to fix payload binding error.
+
+7. Make `"label"` property in `"PublicAssociationDefinitionUpdateRequest"` onject nullable
+
+- **Original**:  
+      "PublicAssociationDefinitionUpdateRequest" : {
+        .
+        .
+        "properties" : {
+          .
+          .
+          "label" : {
+            "type" : "string"
+          }
+        }
+      },
+
+- **Updated**:
+      "PublicAssociationDefinitionUpdateRequest" : {
+        .
+        .
+        "properties" : {
+          .
+          .
+          "label" : {
+            "type" : "string",
+            "nullable": true
+          }
+        }
+      },
+
+- **Reason**: The property `"label"` is updated to be nullable, meaning it can either hold its respective values or be null, to fix payload binding error.
+
 ## OpenAPI cli command
 
 The following command was used to generate the Ballerina client from the OpenAPI specification. The command should be executed from the repository root directory.

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -9,7 +9,7 @@ This document records the sanitation done on top of the official OpenAPI specifi
 The OpenAPI specification is obtained from [Hubspot API Reference](https://github.com/HubSpot/HubSpot-public-api-spec-collection/blob/main/PublicApiSpecs/CRM/Associations%20Schema/Rollouts/130902/v4/associationsSchema.json).
 These changes are done in order to improve the overall usability, and as workarounds for some known language limitations.
 
-1. Change the `url` property of the servers object
+1. Changed the `url` property of the servers object
 
 - **Original**:
 `https://api.hubspot.com`
@@ -19,38 +19,48 @@ These changes are done in order to improve the overall usability, and as workaro
 
 - **Reason**: This change of adding the common prefix `crm/v4/associations` to the base url makes it easier to access endpoints using the client and also eliminates redundancy.
 
-2. Update the API Paths
+2. Updated the API Paths
 
 - **Original**: Paths included common prefix above in each endpoint. (eg: `/crm/v4/associations`)
 - **Updated**: Common prefix is now removed from the endpoints as it is included in the base URL.
 - **Reason**: This change simplifies the API paths, making them shorter and more readable.
 
-3. Update the `date-time` into `datetime` to make it compatible with the Ballerina type conversions.
-
-- **Original**: `"format": "date-time"`
-- **Updated**: `"format": "datetime"`
-- **Reason**: The `date-time` format is not compatible with the OpenAPI tool. Therefore, it is updated to `datetime` to make it compatible with the tool.
-
-4. Make `"label"`,`"userEnforcedMaxToObjectIds"` properties in `"PublicAssociationDefinitionUserConfiguration"` object nullable
+3. Updated the `date-time` into `datetime` to make it compatible with the Ballerina type conversions.
 
 - **Original**:
+
+  ```json
+    { "format" : "date-time" }
+  ```
+
+- **Updated**:
+
+  ```json
+    { "format" : "datetime" }
+  ```
+
+- **Reason**: The `date-time` format is not compatible with the OpenAPI tool. Therefore, it is updated to `datetime` to make it compatible with the tool.
+
+4. Updated the `label` and `userEnforcedMaxToObjectIds` properties in `PublicAssociationDefinitionUserConfiguration` to support nullable values.
+
+- **Original**:
+
+  ```json
     "PublicAssociationDefinitionUserConfiguration" : {
-        ...
         "properties" : {
           "userEnforcedMaxToObjectIds" : {
             "type" : "integer",
             "format" : "int32",
           },
-         .
-         .
           "label" : {
             "type" : "string"
-          },
-          .
-          .
-    }},
+          }
+    }}
+  ```
 
 - **Updated**:
+
+  ```json
      "PublicAssociationDefinitionUserConfiguration" : {
         "properties" : {
           "userEnforcedMaxToObjectIds" : {
@@ -58,114 +68,101 @@ These changes are done in order to improve the overall usability, and as workaro
             "format" : "int32",
             "nullable": true
           },
-         .
-         .
           "label" : {
             "type" : "string",
             "nullable": true
-          },
-          .
-          .
-     }},
+          }
+     }}
+  ```
 
-- **Reason**: The properties `"userEnforcedMaxToObjectIds"` and `"label"` are updated to be nullable, meaning they can either hold their respective values or be null, to fix payload binding error.
+- **Reason**: The properties `userEnforcedMaxToObjectIds` and `label` are updated to be nullable, meaning they can either hold their respective values or be null, to fix a payload binding error.
 
-5. Make `"label"` property in `"PublicAssociationDefinitionCreateRequest"` object nullable
+5. Updated the `label` property in `PublicAssociationDefinitionCreateRequest` to suppoert nullable values.
 
-- **Original**:  
+- **Original**:
+
+  ```json
      "PublicAssociationDefinitionCreateRequest" : {
-        .
-        .
         "properties" : {
-          .
-          .
-          "label" : {
+        "label" : {
             "type" : "string"
           }
         }
-      },
+      }
+  ```
 
 - **Updated**:
+
+  ```json
      "PublicAssociationDefinitionCreateRequest" : {
-        .
-        .
         "properties" : {
-          .
-          .
           "label" : {
             "type" : "string",
             "nullable": true
           }
         }
-      },
+      }
+  ```
 
-- **Reason**: The property `"label"` is updated to be nullable, meaning it can either hold its respective values or be null, to fix payload binding error.
+- **Reason**: The property `label` is updated to be nullable, meaning it can either hold its respective values or be null, to fix a payload binding error.
 
-6. Make `"label"` property in `"AssociationSpecWithLabel"` object nullable
+6. Updated the `label` property in `AssociationSpecWithLabel` to support nullable values
 
 - **Original**:  
+
+  ```json
       "AssociationSpecWithLabel" : {
-        .
-        .
         "properties" : {
-          .
-          .
           "label" : {
             "type" : "string"
-          },
-          .
-          .
+          }
         }
-      },
+      }
+  ```
 
 - **Updated**:
+
+  ```json
       "AssociationSpecWithLabel" : {
-        .
-        .
         "properties" : {
-          .
-          .
           "label" : {
             "type" : "string",
             "nullable":true
-          },
-          .
-          .
+          }
         }
-      },
+    }
+  ```
 
-- **Reason**: The property `"label"` is updated to be nullable, meaning it can either hold its respective values or be null, to fix payload binding error.
+- **Reason**: The property `label` is updated to be nullable, meaning it can either hold its respective values or be null, to fix a payload binding error.
 
-7. Make `"label"` property in `"PublicAssociationDefinitionUpdateRequest"` onject nullable
+7. Updated the `label` property in `PublicAssociationDefinitionUpdateRequest` to support nullable values.
 
-- **Original**:  
+- **Original**:
+
+  ```json
       "PublicAssociationDefinitionUpdateRequest" : {
-        .
-        .
         "properties" : {
-          .
-          .
           "label" : {
             "type" : "string"
           }
         }
-      },
+      }
+  ```
 
 - **Updated**:
+
+  ```json
       "PublicAssociationDefinitionUpdateRequest" : {
-        .
-        .
         "properties" : {
-          .
-          .
           "label" : {
             "type" : "string",
             "nullable": true
           }
         }
-      },
+      }
+  ```
 
-- **Reason**: The property `"label"` is updated to be nullable, meaning it can either hold its respective values or be null, to fix payload binding error.
+- **Reason**: The property `label` is updated to be nullable, meaning it can either hold its respective values or be null, to fix a payload binding error.
 
 ## OpenAPI cli command
 

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -1,6 +1,6 @@
 _Author_:  @Aaishah-Hamdha \
-_Created_: 13.02.2025 \
-_Updated_: 13.02.2025 \
+_Created_: 2025/02/13 \
+_Updated_: 2025/02/13 \
 _Edition_: Swan Lake
 
 # Sanitation for OpenAPI specification


### PR DESCRIPTION
## Purpose
This pull request adds test scenarios, including negative test cases, for multiple API endpoints. It uses a mock service to simulate responses, ensuring the API works correctly in different situations and improving test coverage.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [ ] Checked native-image compatibility
