### PR TITLE
docs: fix README content issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.associations.schema/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.associations.schema/actions/workflows/ci.yml)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.crm.associations.schema.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.associations.schema/commits/master)
-[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.associations.schema.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%hubspot.crm.associations.schema)
+[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.associations.schema.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.crm.associations.schema)
 
 ## Overview
 
 [HubSpot](https://www.hubspot.com/) is an AI-powered customer relationship management (CRM) platform.
 
-The `ballerinax/module-ballerinax-hubspot.crm.associations.schema` connector offers APIs to connect and interact with the [Hubspot Associations Schema API](https://developers.hubspot.com/docs/reference/api/crm/associations/associations-schema) endpoints, specifically based on the [HubSpot REST API](https://developers.hubspot.com/docs/reference/api).
+The `ballerinax/module-ballerinax-hubspot.crm.associations.schema` connector offers APIs to connect and interact with the [HubSpot Associations Schema API](https://developers.hubspot.com/docs/reference/api/crm/associations/associations-schema) endpoints, specifically based on the [HubSpot REST API](https://developers.hubspot.com/docs/reference/api).
 
 ## Setup guide
 
@@ -162,7 +162,7 @@ Replace the `<YOUR_REFRESH_TOKEN>`, `<YOUR_CLIENT_ID>`, and `<YOUR_CLIENT_SECRET
 
 ## Quickstart
 
-To use the `Hubspot CRM Associations Schema` connector in your Ballerina application, update the `.bal` file as follows:
+To use the `HubSpot CRM Associations Schema` connector in your Ballerina application, update the `.bal` file as follows:
 
 ### Step 1: Import the module
 

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -2,7 +2,7 @@
 
 [HubSpot](https://www.hubspot.com/) is an AI-powered customer relationship management (CRM) platform.
 
-The HubSpot connector offers APIs to connect and interact with the [Hubspot Associations Schema API](https://developers.hubspot.com/docs/reference/api/crm/associations/associations-schema) endpoints, specifically based on the [HubSpot REST API](https://developers.hubspot.com/docs/reference/api).
+The HubSpot connector offers APIs to connect and interact with the [HubSpot Associations Schema API](https://developers.hubspot.com/docs/reference/api/crm/associations/associations-schema) endpoints, specifically based on the [HubSpot REST API](https://developers.hubspot.com/docs/reference/api).
 
 ### Key Features
 
@@ -163,7 +163,7 @@ Replace the `<YOUR_REFRESH_TOKEN>`, `<YOUR_CLIENT_ID>`, and `<YOUR_CLIENT_SECRET
 
 ## Quickstart
 
-To use the `Hubspot CRM Associations Schema` connector in your Ballerina application, update the `.bal` file as follows:
+To use the `HubSpot CRM Associations Schema` connector in your Ballerina application, update the `.bal` file as follows:
 
 ### Step 1: Import the module
 


### PR DESCRIPTION
## Purpose

Fixes documentation issues in the top-level `README.md` and `ballerina/README.md` identified in the HubSpot connector docs audit.

Refs ballerina-platform/ballerina-library#8823

## Goals

Bring the README in line with the canonical style used across other connectors (e.g., `asana`, `jira`) and fix a broken GitHub Issues badge link.

## Approach

- Replace `Hubspot` with `HubSpot` in brand-name occurrences in both READMEs (package names, URLs, and identifiers preserved as-is).
- Fix the half-encoded slash in the GitHub Issues badge URL: `module%hubspot.crm.associations.schema` -> `module%2Fhubspot.crm.associations.schema` so the label link resolves.

The `ave`/`have` typo and the duplicated `Ballerina` title issues do not appear in this repo, so no fix was needed there.

## User stories

N/A - documentation-only change.

## Release note

N/A - documentation-only change.

## Documentation

The README itself is the documentation being updated.

## Training

N/A - documentation-only change.

## Certification

N/A - documentation-only change.

## Marketing

N/A - documentation-only change.

## Automation tests
 - Unit tests
   > N/A - documentation-only change.
 - Integration tests
   > N/A - documentation-only change.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A - documentation-only change
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A - documentation-only change.

## Related PRs

- Refs ballerina-platform/ballerina-library#8823

## Migrations (if applicable)

N/A - documentation-only change.

## Test environment

N/A - documentation-only change. Verified the diff is restricted to `README.md` and `ballerina/README.md`.

## Learning

N/A - documentation-only change.